### PR TITLE
fix shell script plugins in flake run

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -61,7 +61,6 @@ rustPlatform.buildRustPackage rec {
     # fix config and theme
     mkdir -p $out/share/rmenu
     cp -vf $src/rmenu/public/config.yaml $out/share/rmenu/config.yaml
-    sed -i "s@~\/\.config\/rmenu\/themes@$out\/themes@g" $out/share/rmenu/config.yaml
     sed -i "s@~\/\.config\/rmenu@$out@g" $out/share/rmenu/config.yaml
     ln -sf  $out/themes/dark.css $out/share/rmenu/style.css
   '';
@@ -69,6 +68,7 @@ rustPlatform.buildRustPackage rec {
   preFixup = ''
     gappsWrapperArgs+=(
       --suffix XDG_CONFIG_DIRS : "$out/share"
+      --suffix PATH : "$out/bin"
     )
   '';
 


### PR DESCRIPTION
- the second sed specific for themes is no longer needed after directory restructuring and the associated changes in default config
- `$out/bin` is now appended to the rmenu-specific path which allows `nix run` and other such temporary install methods to call `rmenu-build` necessary for shellscript based plugins