### PR TITLE
Desktop spec

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711655175,
-        "narHash": "sha256-1xiaYhC3ul4y+i3eicYxeERk8ZkrNjLkrFSb/UW36Zw=",
+        "lastModified": 1714245158,
+        "narHash": "sha256-9P2M0+tf1TE7Z5PwDVwhheuD2mFf6/phPr0Jvl7cxcc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c81edb4b97a51c5bbc54c191763ac71a6517ee",
+        "rev": "2b1f64b358f2cab62617f26b3870fd0ee375d848",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Rmenu currently ignores the desktop file [specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html), notably the properties `Hidden`, `OnlyShowIn`/`NotShowIn` and  `NoDisplay`.
This PR aims to fix that partially. The library in use here supports OnlyShowIn and NoDisplay, but hidden and NotShowIn are still broken. Still an improvement.

This is the mess i am dealing with by *not* runing this patch:
![image](https://github.com/imgurbot12/rmenu/assets/49513131/1db982b3-f530-44db-8468-8f61cc047a0c)
